### PR TITLE
pkcs11Module: add noLabels attribute (default false)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -403,12 +403,11 @@
                   pkcs11-module-quirks = "no-deinit no-operation-state";
                   pkcs11-module-cache-pins = "cache";
                 };
+                noLabels = true;
                 mkEnv = {
                   debug ? 0,
                   extraEnv ? {}
                 }: {
-                  # Yubikeys don't support key labels.
-                  NIXPKCS_NO_LABELS = "1";
                   YKCS11_DBG = builtins.toString debug;
                 } // extraEnv;
               };

--- a/module.nix
+++ b/module.nix
@@ -67,9 +67,11 @@ in
           options = let
             authority = {
               inherit (config) token id;
-              object = name;
               slot-id = if config.slot == null then null else toString config.slot;
               type = "private";
+            } // lib.optionalAttrs (!(config.pkcs11Module.noLabels or false)) {
+              # Only supply this for tokens that support labels.
+              object = name;
             };
             query = lib.optionalAttrs (config.certOptions.pinFile != null) {
               pin-source = "file:${config.certOptions.pinFile}";
@@ -344,6 +346,9 @@ in
             NIXPKCS_STORE_INIT = value.pkcs11Module.storeInit;
           } // lib.optionalAttrs (value.storeInitHook != null) {
             NIXPKCS_STORE_INIT_HOOK = value.storeInitHook;
+          } // lib.optionalAttrs (value.pkcs11Module.noLabels or false) {
+            # For, e.g. Yubikeys, which don't support them.
+            NIXPKCS_NO_LABELS = 1;
           } // lib.optionalAttrs value.debug {
             NIXPKCS_DEBUG = 1;
           });


### PR DESCRIPTION
It's insufficient to set NIXPKCS_NO_LABELS for key generation: the URI needs to not include a label either.

c95a5fb72b0ba24855039b53abcef5f5758dc9bb fixed reading certificates; this fixes signing them too on tokens like the Yubikey.