### PR TITLE
module: add nixpkcs.environment.enable and nixpkcs.uri.enable

### DIFF
--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -110,7 +110,6 @@ let
 
       environment = {
         systemPackages = [ openssl curl ];
-        variables = extraEnv;
       };
 
       systemd.services."nginx" = {


### PR DESCRIPTION
Add a `nixpkcs-uri` tool that converts a key name to a URI. Enable this by default.

Add keypair environment variables to the system environment by default.