### PR TITLE
nixpkcs.sh: fix key IDs over 9

### DIFF
--- a/nixos/tests/nebula.nix
+++ b/nixos/tests/nebula.nix
@@ -43,7 +43,7 @@ let
           ${name} = lib.recursiveUpdate {
             enable = true;
             inherit pkcs11Module extraEnv;
-            id = 1;
+            id = 10;
             debug = true;
             keyOptions = {
               algorithm = "EC";
@@ -194,7 +194,7 @@ in testers.runNixOSTest {
             ca = lib.recursiveUpdate {
               enable = true;
               inherit pkcs11Module extraEnv;
-              id = 2;
+              id = 20;
               debug = true;
               keyOptions = {
                 algorithm = "EC";

--- a/nixpkcs.sh
+++ b/nixpkcs.sh
@@ -165,7 +165,7 @@ p11tool() {
   local op_mode="$1"
   shift
 
-  local args=(--token-label "$token" --id "$id")
+  local args=(--token-label "$token" --id "$(printf '%x' "$id")")
 
   if [ $use_label -ne 0 ]; then
     args+=(--label "$label")


### PR DESCRIPTION
Oooops, pkcs11-tool takes hex, not decimal. :-)