### PR TITLE
nixpkcs.keypairs.*.id: support huge key IDs

### DIFF
--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -32,7 +32,7 @@ let
           ${name} = lib.recursiveUpdate {
             enable = true;
             inherit pkcs11Module extraEnv storeInitHook;
-            id = 1;
+            id = 244837814094590; # 0xDEADBEEFCAFE
             debug = true;
             keyOptions = {
               algorithm = "RSA";

--- a/nixpkcs.sh
+++ b/nixpkcs.sh
@@ -165,7 +165,14 @@ p11tool() {
   local op_mode="$1"
   shift
 
-  local args=(--token-label "$token" --id "$(printf '%x' "$id")")
+  # Remove leading zeroes from the ID.
+  local id_str
+  id_str="$(printf '%016x' "$id")"
+  if [[ "$id_str" =~ ^(00)+([0-9a-f]{2,})$ ]]; then
+    id_str="${BASH_REMATCH[2]}"
+  fi
+
+  local args=(--token-label "$token" --id "$id_str")
 
   if [ $use_label -ne 0 ]; then
     args+=(--label "$label")


### PR DESCRIPTION
Some tokens (the nitrokey) actually use an ASCII string for the key ID.
This isn't very common (both the yubikey and TPM2 use positive integers)
but we should be able to support it by passing a very large number to
the `id` value and converting it to URL notation as a big-endian
integer.

Update tests for this case.

----

As it turns out, pkcs11-tool actually takes CKA_ID, not a hex
encoded integer. Pad it to a multiple of 2 in length the same
way we do for the URI in Nix.