### PR TITLE
tests: check high key IDs and nixpkcs-uri

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
           tpmNebulaTest = pkgs.callPackage ./nixos/tests/nebula.nix {
             inherit self nixpkgs;
             inherit (pkgs.tpm2-pkcs11) pkcs11Module;
+            baseKeyId = 256; # swtpm supports rather high IDs, we should test them...
             extraKeypairOptions = {
               token = "nixpkcs";
             };

--- a/nixos/tests/nginx.nix
+++ b/nixos/tests/nginx.nix
@@ -139,9 +139,12 @@ in testers.runNixOSTest {
 
       # Wait for the keys to exist.
       nginx.wait_until_succeeds('openssl x509 -in /etc/keys/nixpkcs.local.crt -noout -subject | grep -q "nixpkcs.local"')
-      nginx.succeed('systemctl restart nginx')
+
+      # It should be in nixpkcs-uri too.
+      nginx.succeed("nixpkcs-uri | tee /dev/stderr | grep -qE '^nginx[[:space:]]+pkcs11:.*?;?id=%DE%AD%BE%EF%CA%FE(;|$)'")
 
       # Wait for the webserver to come up, and make sure it's reliable thereafter
+      nginx.succeed('systemctl restart nginx')
       cmd = 'curl --cacert /etc/keys/nixpkcs.local.crt https://nixpkcs.local/index.html | tee /dev/stderr | grep "Hello, nixpkcs!"'
       nginx.wait_until_succeeds(cmd)
       for i in range(100):


### PR DESCRIPTION
We should check that high key IDs work properly, and that the nixpkcs-uri tool outputs the correct keys.